### PR TITLE
Suspend system when hibernation is not possible

### DIFF
--- a/powernot
+++ b/powernot
@@ -76,6 +76,10 @@ while [[ true ]]; do
         else
           echo "[CRITICAL] Hibernating system...";
           systemctl hibernate
+          if [[ $? ]]; then
+            echo "Hibernating failed (no swap allocated?). Suspending instead";
+            systemctl suspend
+          fi
         fi
       else
         if [[ $remaining -le $DANGER ]]; then


### PR DESCRIPTION
`systemctl hibernate` may fail when there is not enough / no swap allocated.

```
% systemctl hibernate
Failed to hibernate system via logind: Not enough swap space for hibernation
```